### PR TITLE
fix: path in policy contains /data/

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "vault_generic_secret" "this" {
 data "vault_policy_document" "this" {
   rule {
     description  = "Secrets policy for ${var.owner}"
-    path         = local.path
+    path         = "${var.kv_path}/data/${var.owner}"
     capabilities = var.capabilities
   }
 }


### PR DESCRIPTION
The path used in the policy must contains `/data/`.
See https://www.vaultproject.io/docs/secrets/kv/kv-v2#acl-rules