### PR TITLE
fix: typing constraint forces uniform maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In your Terraform file, instanciate the module with:
 
 ```hcl
 module "droopy_secrets" {
-  source = "git@github.com:edgelaboratories/terraform-vault-kv-secrets.git?ref=v0.1.0"
+  source = "git@github.com:edgelaboratories/terraform-vault-kv-secrets.git?ref=v1.0.1"
 
   owner = "droopy"
   secrets = {

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,8 @@ variable "owner" {
 }
 
 variable "secrets" {
-  description = "A mapping of key/value that will be saved in the secrets KV store."
-  type        = map
+  description = "A secret that will be saved in the secrets KV store (it will be JSON encoded)."
+  type        = any
   default     = {}
   sensitive   = true
 }


### PR DESCRIPTION
> The keyword map is a shorthand for map(any), which accepts any element type as long as every element **is the same type**.

For the redis secrets, it turns the `true` into `"true"`... /cc @edgelaboratories/pre-pricing 